### PR TITLE
Correct trigger spelling

### DIFF
--- a/.jenkins.yaml
+++ b/.jenkins.yaml
@@ -1,7 +1,7 @@
 builders:
   - script
 triggers:
-  cron: "@seekly"
+  cron: "@weekly"
 slack:
   room: "devops-builds"
 clean_workspace: true


### PR DESCRIPTION
This corrects the spelling of the trigger name so jenkins can parse it.